### PR TITLE
Removed inclusions of ai/aliases/stable_singleplayer.cfg

### DIFF
--- a/ai/eng/boss_targeting.cfg
+++ b/ai/eng/boss_targeting.cfg
@@ -9,7 +9,7 @@
 #
 # _TARGETS_LIST must be a valid Lua list.
 #
-#define AI_BOSS_TARGETING_ENGINE _TARGETS_LIST
+#define AI_BOSS_TARGETING_ENGINE _SIDE _TARGETS_LIST
     [engine]
         name="lua"
         code= <<
@@ -18,7 +18,7 @@
         >>
     [/engine]
     [modify_ai]
-        side=2
+        side={_SIDE}
         action=add
         path="stage[main_loop].candidate_action[]"
         [candidate_action]

--- a/ai/fake/npc.cfg
+++ b/ai/fake/npc.cfg
@@ -6,7 +6,6 @@ Crow,Falcon,Shaxthal Razorbird,Shaxthal Thunderbird,Shaxthal Worm#enddef
 # wmlindent: stop ignoring
 
 #define IS_HOSTILE_NPC
-    {ai/aliases/stable_singleplayer.cfg}
     [ai]
         {AI_SIMPLE_ALWAYS_ASPECT aggression       1.0}
         {AI_SIMPLE_ALWAYS_ASPECT leader_value     0.0}

--- a/episode1/scenarios/01_The_Skirmish.cfg
+++ b/episode1/scenarios/01_The_Skirmish.cfg
@@ -55,7 +55,6 @@
         user_team_name= _ "team_name^Townsmen"
         {ARAGWAITH_FLAG}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT grouping            no}
             {AI_SIMPLE_ALWAYS_ASPECT passive_leader      yes}
@@ -167,7 +166,6 @@
         user_team_name= _ "team_name^Enemies"
         {CHAOS_FLAG}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             #
             # These bastards know about Galas et al.

--- a/episode1/scenarios/02_High_Pass.cfg
+++ b/episode1/scenarios/02_High_Pass.cfg
@@ -58,7 +58,6 @@
         {GOLD 170 190 220}
         {INCOME 3 4 6}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             [goal]
                 [criteria]
@@ -178,7 +177,6 @@
         recruit="Skeleton, Skeleton Archer, Walking Corpse"
         {GOLD 160 190 220}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             [goal]
                 [criteria]

--- a/episode1/scenarios/04_Terror_at_Dusk.cfg
+++ b/episode1/scenarios/04_Terror_at_Dusk.cfg
@@ -72,7 +72,6 @@
         {GOLD 130 145 160}
         recruit=Shaxthal Drone, Shaxthal Runner Drone, Shaxthal Razorbird
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT recruitment_pattern "mixed fighter,mixed fighter,mixed fighter,scout"}
         [/ai]
@@ -95,7 +94,6 @@
         {GOLD 120 130 140}
         recruit=Shaxthal Runner Drone, Shaxthal Razorbird, Shaxthal Drone
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT recruitment_pattern "mixed fighter,mixed fighter,mixed fighter,scout"}
         [/ai]
@@ -118,7 +116,6 @@
         {GOLD 120 150 170}
         recruit=Shaxthal Runner Drone, Chaos Invader, Shaxthal Drone, Chaos Headhunter
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT recruitment_pattern "mixed fighter,scout,fighter,fighter,scout"}
         [/ai]

--- a/episode1/scenarios/05_Bay_of_Tirigaz.cfg
+++ b/episode1/scenarios/05_Bay_of_Tirigaz.cfg
@@ -53,7 +53,6 @@
             {TRAIT_STRONG}
         [/modifications]
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_NO_SCOUTS}
             {AI_SIMPLE_ALWAYS_ASPECT aggression 0.80}
@@ -175,7 +174,6 @@
             {TRAIT_RESILIENT}
         [/modifications]
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT aggression           1.00}
             {AI_SIMPLE_ALWAYS_ASPECT caution              0.00}
@@ -255,7 +253,6 @@
             {TRAIT_INTELLIGENT}
         [/modifications]
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT aggression           1.00}
             {AI_SIMPLE_ALWAYS_ASPECT caution              0.00}
@@ -317,7 +314,6 @@
         hidden=yes
         no_leader=yes
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             [goal]
                 [criteria]
@@ -340,7 +336,6 @@
         hidden=yes
         no_leader=yes
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             [goal]
                 [criteria]

--- a/episode1/scenarios/07_The_Search_for_the_Past.cfg
+++ b/episode1/scenarios/07_The_Search_for_the_Past.cfg
@@ -43,7 +43,6 @@
         hidden=yes
         no_leader=yes
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_NO_SCOUTS}
             {AI_SIMPLE_ALWAYS_ASPECT aggression 10.0}
@@ -63,7 +62,6 @@
         income=-2
         village_gold=0
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_NO_SCOUTS}
             {AI_SIMPLE_ALWAYS_ASPECT aggression 10.0}
@@ -79,7 +77,6 @@
         no_leader=yes
         hidden=yes
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_NO_SCOUTS}
             {AI_SIMPLE_ALWAYS_ASPECT aggression 10.0}
@@ -95,7 +92,6 @@
         no_leader=yes
         hidden=yes
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_NO_SCOUTS}
             {AI_SIMPLE_ALWAYS_ASPECT aggression 10.0}
@@ -111,7 +107,6 @@
         no_leader=yes
         hidden=yes
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_NO_SCOUTS}
             {AI_SIMPLE_ALWAYS_ASPECT aggression 10.0}

--- a/episode1/scenarios/09_The_Triad_part_2.cfg
+++ b/episode1/scenarios/09_The_Triad_part_2.cfg
@@ -82,7 +82,6 @@
             {TRAIT_RESILIENT}
         [/modifications]
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT aggression 200.00}
             {AI_SIMPLE_ALWAYS_ASPECT caution      0.00}

--- a/episode1/scenarios/09_The_Triad_part_3.cfg
+++ b/episode1/scenarios/09_The_Triad_part_3.cfg
@@ -61,7 +61,6 @@
         no_leader=yes
         {NO_ECONOMY}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT aggression 200.00}
             {AI_SIMPLE_ALWAYS_ASPECT caution      0.00}

--- a/episode1/scenarios/10_Tears.cfg
+++ b/episode1/scenarios/10_Tears.cfg
@@ -51,7 +51,6 @@
         user_team_name= _ "team_name^Enemies"
         {CHAOS_FLAG}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             [goal]
                 [criteria]
@@ -98,7 +97,6 @@
         user_team_name= _ "team_name^Enemies"
         {CHAOS_FLAG}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             [goal]
                 [criteria]

--- a/episode1/scenarios/11_Return_to_Wesmere_part_1.cfg
+++ b/episode1/scenarios/11_Return_to_Wesmere_part_1.cfg
@@ -118,7 +118,6 @@
         user_team_name= _ "team_name^Enemies"
         {CHAOS_FLAG}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {RTW1_ENEMY_TARGETS}
         [/ai]
@@ -144,7 +143,6 @@
         user_team_name= _ "team_name^Wesmere Defense"
         {CHAOS_FLAG}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {RTW1_ENEMY_TARGETS}
         [/ai]
@@ -182,7 +180,6 @@
         user_team_name= _ "team_name^Enemies"
         {CHAOS_FLAG}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT grouping     no}
             {AI_SIMPLE_ALWAYS_ASPECT aggression 1.00}

--- a/episode1/scenarios/11_Return_to_Wesmere_part_2.cfg
+++ b/episode1/scenarios/11_Return_to_Wesmere_part_2.cfg
@@ -72,7 +72,6 @@
         no_leader=yes
         {NO_ECONOMY}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {RTW_SHARED_AI_ASPECTS}
 
@@ -108,7 +107,6 @@
         no_leader=yes
         {NO_ECONOMY}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {RTW_SHARED_AI_ASPECTS}
         [/ai]
@@ -125,7 +123,6 @@
         no_leader=yes
         {NO_ECONOMY}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {RTW_SHARED_AI_ASPECTS}
         [/ai]

--- a/episode1/scenarios/12_The_Queen.cfg
+++ b/episode1/scenarios/12_The_Queen.cfg
@@ -66,7 +66,6 @@
         no_leader=yes
         {NO_ECONOMY}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {RTW_SHARED_AI_ASPECTS}
         [/ai]
@@ -109,7 +108,6 @@
         no_leader=yes
         {NO_ECONOMY}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {RTW_SHARED_AI_ASPECTS}
         [/ai]
@@ -126,7 +124,6 @@
         no_leader=yes
         {NO_ECONOMY}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {RTW_SHARED_AI_ASPECTS}
         [/ai]

--- a/episode2/scenarios/04_Shifting_Allegiances.cfg
+++ b/episode2/scenarios/04_Shifting_Allegiances.cfg
@@ -62,7 +62,6 @@
         {GOLD 135 120 110}
         recruit=Demon,Faerie Sprite,Animated Rock
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT recruitment_pattern "archer,mixed fighter,fighter,fighter,fighter,mixed fighter"}
 
@@ -100,7 +99,6 @@
 
         recruit=Shaxthal Drone,Shaxthal Rayblade,Shaxthal Razorbird
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT passive_leader yes}
             {AI_SIMPLE_ALWAYS_ASPECT attack_depth ({DIFF 2 3 4})}
@@ -124,7 +122,6 @@
 
         recruit=Shaxthal Runner Drone,Shaxthal Rayblade
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT passive_leader yes}
             {AI_SIMPLE_ALWAYS_ASPECT attack_depth ({DIFF 2 3 4})}

--- a/episode2/scenarios/05_The_Eastern_Front.cfg
+++ b/episode2/scenarios/05_The_Eastern_Front.cfg
@@ -39,7 +39,6 @@
         recruit=Elvish Archer,Shaxthal Rayblade,Elvish Scout,Elvish Acolyte,Elvish Shaman
         {GOLD 180 200 220}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT attack_depth ({DIFF 3 4 4})}
             {AI_SIMPLE_ALWAYS_ASPECT recruitment_pattern "scout,archer,healer,fighter,mixed fighter,scout,archer"}
@@ -65,7 +64,6 @@
         recruit=Elvish Archer,Elvish Fighter,Elvish Scout,Elvish Shaman
         {GOLD 170 180 190}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT attack_depth ({DIFF 2 3 4})}
             # Don't let the leader go scouting for villages.
@@ -93,7 +91,6 @@
         recruit=Elvish Archer,Elvish Fighter,Elvish Shaman,Elvish Acolyte
         {GOLD 190 200 210}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT attack_depth ({DIFF 3 3 4})}
             {AI_SIMPLE_ALWAYS_ASPECT recruitment_pattern "archer,fighter,fighter,healer,mixed fighter,fighter"}

--- a/episode2/scenarios/06_The_Voyage_Home.cfg
+++ b/episode2/scenarios/06_The_Voyage_Home.cfg
@@ -43,7 +43,6 @@
         recruit=Orcish Archer,Wolf Rider,Orcish Grunt
         {GOLD 150 160 170}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT attack_depth {DIFF 2 3 4} }
             {AI_SIMPLE_ALWAYS_ASPECT recruitment_pattern "fighter,fighter,archer,scout,archer,fighter"}
@@ -70,7 +69,6 @@
         recruit=Goblin Spearman,Wolf Rider,Orcish Archer,Orcish Assassin
         {GOLD 140 160 180}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT attack_depth {DIFF 3 4 4} }
             {AI_SIMPLE_ALWAYS_ASPECT recruitment_pattern "mixed fighter,scout,fighter,archer,scout,archer,fighter"}
@@ -121,7 +119,6 @@
         hidden=yes
         no_leader=yes
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT grouping no}
         [/ai]
@@ -134,7 +131,6 @@
         hidden=yes
         no_leader=yes
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT grouping no}
         [/ai]

--- a/episode2/scenarios/07_Proximus.cfg
+++ b/episode2/scenarios/07_Proximus.cfg
@@ -77,7 +77,6 @@
 
         no_leader=yes
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT aggression 5.00}
             {AI_SIMPLE_ALWAYS_ASPECT caution    0.00}
@@ -96,7 +95,6 @@
         recruit=Walking Corpse,Skeleton,Skeleton Archer,Vampire Bat
         {GOLD 125 150 175}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT aggression 1.00}
             {AI_SIMPLE_ALWAYS_ASPECT caution    0.00}
@@ -136,7 +134,6 @@
         recruit=Elvish Fighter,Elvish Hunter,Elvish Archer,Elvish Shaman
         {GOLD 150 160 170}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT aggression 0.90}
             {AI_SIMPLE_ALWAYS_ASPECT caution    0.01}
@@ -171,7 +168,6 @@
         recruit=Chaos Invoker,Chaos Invader,Chaos Hound
         {GOLD 150 160 170}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT aggression 5.00}
             {AI_SIMPLE_ALWAYS_ASPECT caution    0.00}
@@ -204,7 +200,6 @@
         hidden=yes
         no_leader=yes
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT aggression 5.00}
             {AI_SIMPLE_ALWAYS_ASPECT caution    0.00}

--- a/episode2/scenarios/08_And_then_there_was_Chaos.cfg
+++ b/episode2/scenarios/08_And_then_there_was_Chaos.cfg
@@ -57,7 +57,6 @@
         recruit=Elvish Acolyte,Elvish Fighter,Elvish Archer,Elvish Scout
         {GOLD 140 150 160}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT aggression          0.80}
             {AI_SIMPLE_ALWAYS_ASPECT caution             0.15}
@@ -87,7 +86,6 @@
         recruit=Demon,Imp,Chaos Headhunter,Chaos Invoker
         {GOLD 150 175 190}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT attack_depth        {DIFF 2 3 4} }
             {AI_SIMPLE_ALWAYS_ASPECT recruitment_pattern "mixed fighter,archer,fighter,fighter,mixed fighter,scout,archer"}
@@ -116,7 +114,6 @@
         recruit=Shaxthal Runner Drone,Chaos Hound,Chaos Headhunter,Chaos Invoker
         {GOLD 150 160 170}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT aggression          0.90}
             {AI_SIMPLE_ALWAYS_ASPECT caution             0.10}
@@ -143,7 +140,6 @@
         recruit=Demon,Chaos Invader,Chaos Bowman,Chaos Raider
         {GOLD 160 170 180}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT recruitment_pattern "scout,scout,archer,mixed fighter,archer,fighter,scout,fighter,scout"}
 #ifdef HAVE_SAVE_GOLD_ASPECT_BY_DEFAULT

--- a/episode2/scenarios/09_New_Hive.cfg
+++ b/episode2/scenarios/09_New_Hive.cfg
@@ -58,7 +58,6 @@
 
         recruit=Shaxthal Drone,Shaxthal Rayblade,Chaos Bowman
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT aggression 0.90}
             {AI_SIMPLE_ALWAYS_ASPECT caution    0.10}
@@ -79,7 +78,6 @@
         hidden=yes
         {NO_ECONOMY}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {NH_SHARED_AI_ASPECTS}
         [/ai]

--- a/episode2/scenarios/10_The_Betrayal.cfg
+++ b/episode2/scenarios/10_The_Betrayal.cfg
@@ -50,7 +50,6 @@
         recruit=Shaxthal Drone,Automaton,Chaos Headhunter
         {GOLD 75 80 95}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT aggression 5.00}
             {AI_SIMPLE_ALWAYS_ASPECT caution    0.00}
@@ -82,7 +81,6 @@
         recruit=Chaos Invader,Chaos Invoker,Chaos Headhunter,Shaxthal Runner Drone
         {GOLD 120 130 150}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT aggression           1.00}
             {AI_SIMPLE_ALWAYS_ASPECT caution              0.00}
@@ -110,7 +108,6 @@
         recruit=Shaxthal Drone,Automaton,Chaos Headhunter,Chaos Bowman
         {GOLD 140 150 160}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT attack_depth         {DIFF 2 3 4} }
             {AI_SIMPLE_ALWAYS_ASPECT recruitment_pattern "archer,fighter,scout,mixed fighter,mixed fighter,fighter"}
@@ -140,7 +137,6 @@
         recruit=Demon,Shaxthal Rayblade,Chaos Invoker,Chaos Headhunter
         {GOLD 170 190 210}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT recruitment_pattern "scout,mixed fighter,mixed fighter,archer,fighter,mixed fighter"}
         [/ai]
@@ -170,7 +166,6 @@
         recruit=Demon,Automaton,Chaos Headhunter,Chaos Invoker
         {GOLD 170 180 200}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT attack_depth         {DIFF 2 3 4} }
             {AI_SIMPLE_ALWAYS_ASPECT recruitment_pattern "archer,fighter,mixed fighter,mixed fighter,scout,scout,fighter,archer,mixed fighter"}
@@ -206,7 +201,6 @@
         hidden=yes
         {NO_ECONOMY}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {TB_SHARED_AI_ASPECTS}
         [/ai]

--- a/episode2/scenarios/11_A_Final_Confrontation.cfg
+++ b/episode2/scenarios/11_A_Final_Confrontation.cfg
@@ -53,7 +53,6 @@
 
         {NO_ECONOMY}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT aggression          5.00}
             {AI_SIMPLE_ALWAYS_ASPECT caution             0.00}
@@ -121,7 +120,6 @@
         {NO_ECONOMY}
         recruit=Demon,Imp,Chaos Headhunter
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT aggression          1.00}
             {AI_SIMPLE_ALWAYS_ASPECT caution             0.00}
@@ -187,7 +185,6 @@
         {NO_ECONOMY}
         recruit=Automaton,Shaxthal Drone,Chaos Invoker
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT aggression          1.00}
             {AI_SIMPLE_ALWAYS_ASPECT caution             0.00}
@@ -235,7 +232,6 @@
         hidden=yes
         {NO_ECONOMY}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT aggression 5.00}
             {AI_SIMPLE_ALWAYS_ASPECT caution    0.00}

--- a/episode3/scenarios/01_Beyond_her_Smile.cfg
+++ b/episode3/scenarios/01_Beyond_her_Smile.cfg
@@ -70,7 +70,6 @@
         recruit=Demon,Imp,Chaos Invoker,Chaos Raider
         {GOLD 120 130 140}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT aggression          1.00}
             {AI_SIMPLE_ALWAYS_ASPECT caution             0.20}
@@ -91,7 +90,6 @@
         recruit=Shaxthal Runner Drone,Imp
         {GOLD 110 115 120}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT aggression          1.00}
             {AI_SIMPLE_ALWAYS_ASPECT caution             0.00}
@@ -112,7 +110,6 @@
         recruit=Chaos Headhunter,Chaos Bowman,Chaos Invader
         {GOLD 110 120 125}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT aggression          1.00}
             {AI_SIMPLE_ALWAYS_ASPECT caution             0.00}

--- a/episode3/scenarios/02_01_Return_to_Raelthyn.cfg
+++ b/episode3/scenarios/02_01_Return_to_Raelthyn.cfg
@@ -185,7 +185,6 @@
         village_gold=0
         {NO_INCOME}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             # Try to not attack enemy units unless there is no
             # other option.
@@ -226,7 +225,6 @@
         {GOLD 150 160 170}
         recruit=Chaos Gunner,Chaos Invoker,Chaos Invader,Chaos Raider
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT recruitment_pattern "scout,mixed fighter,fighter,archer,fighter"}
         [/ai]
@@ -266,7 +264,6 @@
         {GOLD 155 160 165}
         recruit=Imp,Demon,Chaos Bowman,Chaos Headhunter
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT recruitment_pattern "scout,mixed fighter,fighter,archer,fighter"}
         [/ai]
@@ -314,7 +311,6 @@
         {GOLD 160 170 180}
         recruit=Shaxthal Runner Drone,Chaos Invader,Chaos Bowman,Vampire Bat
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT recruitment_pattern "fighter,mixed fighter,archer,scout,fighter"}
         [/ai]
@@ -354,7 +350,6 @@
         {GOLD 150 160 170}
         recruit=Demon,Ghoul,Skeleton Archer,Ghost
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT recruitment_pattern "mixed fighter,archer,fighter,mixed fighter,scout,mixed fighter"}
         [/ai]

--- a/episode3/scenarios/03_Amidst_the_Ruins_of_Glamdrol.cfg
+++ b/episode3/scenarios/03_Amidst_the_Ruins_of_Glamdrol.cfg
@@ -132,7 +132,6 @@
         {GOLD 180 190 200}
         recruit=Demon,Demon Zephyr,Shaxthal Rayblade,Shaxthal Protector Drone,Chaos Invader,Chaos Headhunter,Chaos Invoker
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT       aggression          0.90}
             {AI_SIMPLE_ALWAYS_ASPECT       caution             0.10}
@@ -299,7 +298,6 @@
         {GOLD 175 180 185}
         recruit=Chaos Bowman,Chaos Raider,Chaos Invader,Shaxthal Runner Drone
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT       aggression          0.95}
             {AI_SIMPLE_ALWAYS_ASPECT       caution             0.05}

--- a/episode3/scenarios/04_01_Outpost_of_Hell.cfg
+++ b/episode3/scenarios/04_01_Outpost_of_Hell.cfg
@@ -90,7 +90,6 @@
         {GOLD 160 170 180}
         recruit=Demon,Chaos Hound,Ghost,Chaos Bowman
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT recruitment_pattern "scout,mixed fighter,fighter,mixed fighter,archer"}
         [/ai]
@@ -115,7 +114,6 @@
         {GOLD 160 170 180}
         recruit=Young Ogre,Orcish Archer,Orcish Assassin,Saurian Augur
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT recruitment_pattern "fighter,fighter,mixed fighter,archer,healer"}
         [/ai]
@@ -140,7 +138,6 @@
         {GOLD 160 170 180}
         recruit=Chaos Gunner,Chaos Invoker,Chaos Invader,Chaos Headhunter
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT recruitment_pattern "fighter,mixed fighter,archer,scout,fighter,mixed fighter"}
         [/ai]
@@ -165,7 +162,6 @@
         {GOLD 190 200 210}
         recruit=Shaxthal Drone,Shaxthal Razorbird,Shaxthal Rayblade,Psy Crawler,Chaos Invader
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT recruitment_pattern "mixed fighter,scout,fighter,archer,mixed fighter,fighter,mixed fighter"}
         [/ai]
@@ -192,7 +188,6 @@
         {GOLD 190 200 210}
         recruit=Ixthala Fire Dancer,Demon,Chaos Headhunter,Orcish Grunt,Chaos Invoker
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT recruitment_pattern "fighter,mixed fighter,scout,mixed fighter,archer,mixed fighter"}
         [/ai]
@@ -220,7 +215,6 @@
         {GOLD 180 190 200}
         recruit=Chaos Hound,Valdemon Basher,Blood Imp,Chaos Bowman,Shaxthal Runner Drone
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT recruitment_pattern "archer,mixed fighter,fighter,fighter,mixed fighter,archer"}
         [/ai]
@@ -248,7 +242,6 @@
         {INCOME 6 8 10}
         recruit=Imp,Blood Imp,Valdemon Basher,Serpent Messenger,Demon Zephyr,Shaxthal Runner Drone,Shaxthal Protector Drone,Chaos Crossbowman,Chaos Bowman,Chaos Raider
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT recruitment_pattern "fighter,mixed fighter,scout,archer,fighter,scout"}
         [/ai]

--- a/episode3/scenarios/05_Pass_of_Sorrows.cfg
+++ b/episode3/scenarios/05_Pass_of_Sorrows.cfg
@@ -91,7 +91,6 @@
         recruit=Skeleton,Ghost,Skeleton Archer
 #endif
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT recruitment_pattern "fighter,fighter,archer,archer,scout,fighter"}
         [/ai]
@@ -135,7 +134,6 @@
         {INCOME 1 2 3}
         recruit=Ghoul,Walking Corpse,Vampire Bat,Skeleton Archer
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT recruitment_pattern "fighter,fighter,archer,scout,scout"}
         [/ai]
@@ -168,7 +166,6 @@
         no_leader=yes
         hidden=yes
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT aggression 1.00}
             {AI_SIMPLE_ALWAYS_ASPECT caution    0.00}

--- a/episode3/scenarios/07A_Dark_Fire_part_2.cfg
+++ b/episode3/scenarios/07A_Dark_Fire_part_2.cfg
@@ -62,7 +62,6 @@
 
         {NO_ECONOMY}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT aggression        1.00}
             {AI_SIMPLE_ALWAYS_ASPECT leader_aggression 1.00}

--- a/episode3/scenarios/07B_Dark_Sea.cfg
+++ b/episode3/scenarios/07B_Dark_Sea.cfg
@@ -244,7 +244,6 @@
     hidden=yes
     controller=null
 
-    {ai/aliases/stable_singleplayer.cfg}
     [ai]
         {_AI_CONFIGURATION}
         # None of these sides work properly with recruitment_save_gold given

--- a/episode3/scenarios/08A_Interim.cfg
+++ b/episode3/scenarios/08A_Interim.cfg
@@ -56,7 +56,6 @@
 
         {NO_ECONOMY}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT aggression        1.00}
             {AI_SIMPLE_ALWAYS_ASPECT leader_aggression 1.00}

--- a/episode3/scenarios/08B_Destiny_part_1.cfg
+++ b/episode3/scenarios/08B_Destiny_part_1.cfg
@@ -111,7 +111,6 @@
 
         {NO_ECONOMY}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT aggression        1.00}
             {AI_SIMPLE_ALWAYS_ASPECT leader_aggression 1.00}
@@ -183,7 +182,6 @@
 
         {NO_ECONOMY}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT aggression        1.00}
             {AI_SIMPLE_ALWAYS_ASPECT leader_aggression 1.00}
@@ -212,7 +210,6 @@
 
         {NO_ECONOMY}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT aggression        1.00}
             {AI_SIMPLE_ALWAYS_ASPECT caution           0.00}

--- a/episode3/scenarios/08C_Breakdown.cfg
+++ b/episode3/scenarios/08C_Breakdown.cfg
@@ -20,7 +20,6 @@
     {INDOORS_HIVE}
 
 #define INT_STANDARD_ENEMY_AI
-    {ai/aliases/stable_singleplayer.cfg}
     [ai]
         {AI_SIMPLE_ALWAYS_ASPECT aggression        9.00}
         {AI_SIMPLE_ALWAYS_ASPECT leader_aggression 9.00}

--- a/episode3/scenarios/08D_Destiny_part_2.cfg
+++ b/episode3/scenarios/08D_Destiny_part_2.cfg
@@ -89,7 +89,6 @@
             {TRAIT_RESILIENT}
         [/modifications]
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT passive_leader yes}
         [/ai]
@@ -337,7 +336,6 @@
         no_leader=yes
         hidden=yes
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {AI_SIMPLE_ALWAYS_ASPECT aggression        1.00}
             {AI_SIMPLE_ALWAYS_ASPECT leader_aggression 1.00}

--- a/episode3/scenarios/09_Dark_Depths.cfg
+++ b/episode3/scenarios/09_Dark_Depths.cfg
@@ -69,7 +69,7 @@
         [ai]
             {FINALE_B_SHARED_AI_PARAMS}
 
-            {AI_BOSS_TARGETING_ENGINE <<{"Elyssa","Elynia"}>>}
+            {AI_BOSS_TARGETING_ENGINE 2 <<{"Elyssa","Elynia"}>>}
 
             [goal]
                 [criteria]
@@ -111,7 +111,7 @@
         [ai]
             {FINALE_B_SHARED_AI_PARAMS}
 
-            {AI_BOSS_TARGETING_ENGINE <<{"Elyssa","Elynia"}>>}
+            {AI_BOSS_TARGETING_ENGINE 3 <<{"Elyssa","Elynia"}>>}
 
             [goal]
                 [criteria]

--- a/episode3/scenarios/09_Dark_Depths.cfg
+++ b/episode3/scenarios/09_Dark_Depths.cfg
@@ -149,7 +149,6 @@
         canrecruit=yes
         type=Giant Spider
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {FINALE_B_SHARED_AI_PARAMS}
         [/ai]
@@ -177,7 +176,6 @@
         canrecruit=yes
         type=Giant Spider
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {FINALE_B_SHARED_AI_PARAMS}
         [/ai]
@@ -205,7 +203,6 @@
         canrecruit=yes
         type=Psy Mindraider
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {FINALE_B_SHARED_AI_PARAMS}
         [/ai]
@@ -238,7 +235,6 @@
 
         {NO_ECONOMY}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {FINALE_B_SHARED_AI_PARAMS}
         [/ai]

--- a/episode3/scenarios/10_Blood.cfg
+++ b/episode3/scenarios/10_Blood.cfg
@@ -110,7 +110,6 @@
 
         {NO_ECONOMY}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {FINALE_B_SHARED_AI_PARAMS}
         [/ai]
@@ -139,7 +138,6 @@
 
         {NO_ECONOMY}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {FINALE_B_SHARED_AI_PARAMS}
         [/ai]
@@ -165,7 +163,6 @@
 
         {NO_ECONOMY}
 
-        {ai/aliases/stable_singleplayer.cfg}
         [ai]
             {FINALE_B_SHARED_AI_PARAMS}
         [/ai]

--- a/episode3/scenarios/10_Blood.cfg
+++ b/episode3/scenarios/10_Blood.cfg
@@ -73,7 +73,7 @@
         [ai]
             {FINALE_B_SHARED_AI_PARAMS}
 
-            {AI_BOSS_TARGETING_ENGINE <<{"Elyssa","Elynia"}>>}
+            {AI_BOSS_TARGETING_ENGINE 2 <<{"Elyssa","Elynia"}>>}
 
             [goal]
                 [criteria]


### PR DESCRIPTION
According to mattsc, this inclusion is redundant as there are no other AI engines
loaded besides the default one